### PR TITLE
Improvements: Bug fixes, SSE support, and HA 2025.10+ compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ venv
 .venv
 .coverage
 .idea
+
+# Temporary development files
+/temp/
+*.ps1
+hacs_custom_repos_backup.json

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ For DeviReg climate there is a [new Home Assistant Addon](https://github.com/bob
 For these devices no external openHAB setup is needed anymore.
 
 # 2025: Work by [MrDix](https://github.com/MrDix/ha-openhab)
-* Fix NotImplementedError when comparing DateTimeItem objects  
-  This covers the ticket [#31](https://github.com/kubawolanin/ha-openhab/issues/31)
-* Add SSE support for real-time updates from openHAB  
-  This covers the ticket [#28](https://github.com/kubawolanin/ha-openhab/issues/28)
+* Fix NotImplementedError when comparing DateTimeItem objects ([#1](https://github.com/MrDix/ha-openhab/issues/1)/[#31](https://github.com/kubawolanin/ha-openhab/issues/31))  
+  Resolved by changing comparison from `!= None` to `is not None` in entity.py to avoid triggering the `__ne__` operator on DateTimeItem objects
+* Add SSE support for real-time updates from openHAB ([#2](https://github.com/MrDix/ha-openhab/issues/2)/[28](https://github.com/kubawolanin/ha-openhab/issues/28))  
+  Implemented Server-Sent Events listener for real-time state synchronization, reducing delay from 15+ seconds to ~0.5-1 second
+* Fix deprecated constant imports for Home Assistant 2025.10+ compatibility ([#3](https://github.com/MrDix/ha-openhab/issues/3))  
+  Updated media_player.py and light.py to use enum-based constants instead of deprecated string constants
 
 # openHAB custom integration for Home Assistant
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
-# 2024 Update #
-For DeviReg climate there is new Home Assistant Addon
-https://github.com/bob-tm/ha-devireg-mqtt-addon
-No more external servers!
+# 2021: Work by [kubawolanin](https://github.com/kubawolanin/ha-openhab)
+Original Plugin development
+
+# 2023: Work by [hauserbauten](https://github.com/hauserbauten/ha-openhab)
+Fix GitHub issue link [#23](https://github.com/kubawolanin/ha-openhab/issues/23)
+
+# 2024: Work by [bob-tm](https://github.com/bob-tm/ha-openhab)
+* Fix for Home Assistant Version 2024.6 internal API change.   
+  This covers the following tickets: [#22](https://github.com/kubawolanin/ha-openhab/issues/22),[#29](https://github.com/kubawolanin/ha-openhab/issues/29),[#29](https://github.com/kubawolanin/ha-openhab/issues/29),[#30](https://github.com/kubawolanin/ha-openhab/issues/30)
+* Adding devireg thermostat support
+For DeviReg climate there is a [new Home Assistant Addon](https://github.com/bob-tm/ha-devireg-mqtt-addon).  
+For these devices no external openHAB setup is needed anymore.
+
+# 2025: Work by [MrDix](https://github.com/MrDix/ha-openhab)
+* Fix NotImplementedError when comparing DateTimeItem objects  
+  This covers the ticket [#31](https://github.com/kubawolanin/ha-openhab/issues/31)
+* Add SSE support for real-time updates from openHAB  
+  This covers the ticket [#28](https://github.com/kubawolanin/ha-openhab/issues/28)
 
 # openHAB custom integration for Home Assistant
 
@@ -33,7 +47,7 @@ _Component to integrate with [openHAB][openHAB]._
 ## HACS Installation
 
 1. Go to http://homeassistant.local:8123/hacs/integrations
-1. Add `https://github.com/bob-tm/ha-openhab` custom integration repository
+1. Add `https://github.com/MrDix/ha-openhab` custom integration repository
 1. Download the openHAB repository
 1. Go to http://homeassistant.local:8123/config/integrations and add new integration
 1. Choose "openHAB" from the list and follow the config flow steps

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 Original Plugin development
 
 # 2023: Work by [hauserbauten](https://github.com/hauserbauten/ha-openhab)
-Fix GitHub issue link [#23](https://github.com/kubawolanin/ha-openhab/issues/23)
+Fix GitHub issue link ([#23](https://github.com/kubawolanin/ha-openhab/issues/23))
 
 # 2024: Work by [bob-tm](https://github.com/bob-tm/ha-openhab)
 * Fix for Home Assistant Version 2024.6 internal API change.   
-  This covers the following tickets: [#22](https://github.com/kubawolanin/ha-openhab/issues/22),[#29](https://github.com/kubawolanin/ha-openhab/issues/29),[#29](https://github.com/kubawolanin/ha-openhab/issues/29),[#30](https://github.com/kubawolanin/ha-openhab/issues/30)
+  This covers the following tickets: ([#22](https://github.com/kubawolanin/ha-openhab/issues/22),[#29](https://github.com/kubawolanin/ha-openhab/issues/29),[#29](https://github.com/kubawolanin/ha-openhab/issues/29),[#30](https://github.com/kubawolanin/ha-openhab/issues/30))
 * Adding devireg thermostat support
 For DeviReg climate there is a [new Home Assistant Addon](https://github.com/bob-tm/ha-devireg-mqtt-addon).  
 For these devices no external openHAB setup is needed anymore.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,21 @@ Fix GitHub issue link ([#23](https://github.com/kubawolanin/ha-openhab/issues/23
 For DeviReg climate there is a [new Home Assistant Addon](https://github.com/bob-tm/ha-devireg-mqtt-addon).  
 For these devices no external openHAB setup is needed anymore.
 
-# 2025: Work by [MrDix](https://github.com/MrDix/ha-openhab)
+# 2025/2026: Work by [MrDix](https://github.com/MrDix/ha-openhab)
 * Fix NotImplementedError when comparing DateTimeItem objects ([#1](https://github.com/MrDix/ha-openhab/issues/1)/[#31](https://github.com/kubawolanin/ha-openhab/issues/31))  
   Resolved by changing comparison from `!= None` to `is not None` in entity.py to avoid triggering the `__ne__` operator on DateTimeItem objects
-* Add SSE support for real-time updates from openHAB ([#2](https://github.com/MrDix/ha-openhab/issues/2)/[28](https://github.com/kubawolanin/ha-openhab/issues/28))  
-  Implemented Server-Sent Events listener for real-time state synchronization, reducing delay from 15+ seconds to ~0.5-1 second
+* Add SSE support for real-time updates from openHAB ([#2](https://github.com/MrDix/ha-openhab/issues/2)/[#28](https://github.com/kubawolanin/ha-openhab/issues/28))  
+  Implemented Server-Sent Events listener for real-time state synchronization, reducing delay from 15+ seconds to ~0ms via direct state injection
+* Fix SSE state changes not reflected in Home Assistant ([#4](https://github.com/MrDix/ha-openhab/issues/4))  
+  Direct state injection via `_update_item_from_sse_payload()`, echo suppression via `track_ha_command()`, polling re-enabled on SSE failure
 * Fix deprecated constant imports for Home Assistant 2025.10+ compatibility ([#3](https://github.com/MrDix/ha-openhab/issues/3))  
   Updated media_player.py and light.py to use enum-based constants instead of deprecated string constants
+* Fix deprecated `self.config_entry` assignment in OptionsFlow for HA 2025.12+ ([bob-tm#11](https://github.com/bob-tm/ha-openhab/issues/11))  
+  Removed explicit assignment in `OpenHABOptionsFlowHandler.__init__()`; HA sets it automatically via the parent class
+* Fix invalid entity ID for openHAB items with uppercase/special characters for HA 2026.2+ ([bob-tm#12](https://github.com/bob-tm/ha-openhab/issues/12))  
+  Item names are now passed through `slugify()` before being used as entity IDs; `unique_id` retains the original name
+* Loosen `python-openhab` version pin from `==2.17.1` to `>=2.17.1`  
+  Allows HA to install the latest compatible version instead of a pinned older release
 
 # openHAB custom integration for Home Assistant
 
@@ -106,8 +114,8 @@ If you want to contribute to this please read the [Contribution guidelines](CONT
 [openhab]: https://openhab.org
 [buymecoffee]: https://www.buymeacoffee.com/kubawolanin
 [buymecoffeebadge]: https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg?style=for-the-badge
-[commits-shield]: https://img.shields.io/github/commit-activity/y/kubawolanin/ha-openhab.svg?style=for-the-badge
-[commits]: https://github.com/bob-tm/ha-openhab/commits/master
+[commits-shield]: https://img.shields.io/github/commit-activity/y/MrDix/ha-openhab.svg?style=for-the-badge
+[commits]: https://github.com/MrDix/ha-openhab/commits/master
 [hacs]: https://github.com/ludeeus/hacs
 [hacsbadge]: https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge
 [discord]: https://discord.gg/Qa5fW2R
@@ -116,6 +124,6 @@ If you want to contribute to this please read the [Contribution guidelines](CONT
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg?style=for-the-badge
 [forum]: https://community.home-assistant.io/
 [license-shield]: https://img.shields.io/github/license/kubawolanin/ha-openhab.svg?style=for-the-badge
-[maintenance-shield]: https://img.shields.io/badge/maintainer-Kuba%20Wolanin%20%40kubawolanin-blue.svg?style=for-the-badge
-[releases-shield]: https://img.shields.io/github/release/bob-tm/ha-openhab.svg?style=for-the-badge
-[releases]: https://github.com/bob-tm/ha-openhab/releases
+[maintenance-shield]: https://img.shields.io/badge/maintainer-MrDix-blue.svg?style=for-the-badge
+[releases-shield]: https://img.shields.io/github/release/MrDix/ha-openhab.svg?style=for-the-badge
+[releases]: https://github.com/MrDix/ha-openhab/releases

--- a/custom_components/openhab/__init__.py
+++ b/custom_components/openhab/__init__.py
@@ -66,6 +66,10 @@ async def async_setup_entry(
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload the config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # Shutdown SSE listener before unloading
+    await coordinator.async_shutdown()
+
     if unload_ok := await hass.config_entries.async_unload_platforms(
         entry, [platform for platform in PLATFORMS if platform in coordinator.platforms]
     ):

--- a/custom_components/openhab/api.py
+++ b/custom_components/openhab/api.py
@@ -107,23 +107,28 @@ def fetch_all_items(oh):
         if k in dr:
             is_devi_unit = True
 
+        # Only process as devireg_attr if the parent group is actually a devireg unit
         if len(v.groupNames)>0:
-            if v.groupNames[0] in dr:
-                is_devi_attr = True
-                v.parent_device_name = v.groupNames[0]
+            parent_group = v.groupNames[0]
+            if parent_group in dr:
+                # Check if parent is actually a devireg unit (not just any group)
+                parent_item = dr[parent_group]
+                if hasattr(parent_item, 'type_ex') and parent_item.type_ex == 'devireg_unit':
+                    is_devi_attr = True
+                    v.parent_device_name = parent_group
 
-                if v.label in [
-                        'State',  'Mode', 'Room temperature', 'Floor temperature',
-                        'Heater on time in last 7 days', 'Heater on time in last 30 days', 'Total heater on time']:
-                    v.type_ex = 'devireg_attr_ui_sensor'
-                elif v.label in ['Heating state', 'Window open']:
-                    v.type_ex = 'devireg_attr_ui_binary_sensor'
-                elif v.label in ['Enable minimum floor temperature', 'Open window detection', 'Screen lock', 'Temperature forecasting']:
-                    v.type_ex = 'devireg_attr_ui_switch'
-                else:
-                    v.type_ex = 'devireg_attr'
-                    
-                LOGGER.debug(f"Item {k} classified as {v.type_ex} (parent: {v.parent_device_name})")
+                    if v.label in [
+                            'State',  'Mode', 'Room temperature', 'Floor temperature',
+                            'Heater on time in last 7 days', 'Heater on time in last 30 days', 'Total heater on time']:
+                        v.type_ex = 'devireg_attr_ui_sensor'
+                    elif v.label in ['Heating state', 'Window open']:
+                        v.type_ex = 'devireg_attr_ui_binary_sensor'
+                    elif v.label in ['Enable minimum floor temperature', 'Open window detection', 'Screen lock', 'Temperature forecasting']:
+                        v.type_ex = 'devireg_attr_ui_switch'
+                    else:
+                        v.type_ex = 'devireg_attr'
+                        
+                    LOGGER.debug(f"Item {k} classified as {v.type_ex} (parent: {v.parent_device_name})")
 
 
         if is_devi_unit==False:

--- a/custom_components/openhab/api.py
+++ b/custom_components/openhab/api.py
@@ -78,11 +78,13 @@ def fetch_all_items_new(oh):
 
 def fetch_all_items(oh):
     import json
+    from .const import LOGGER
 
     dr = {}
     devi_things = get_from_Things(oh)
     items = oh.fetch_all_items()
 
+    devireg_units_found = []
     for k,v in items.items():
         n = type(v).__name__
         v.type_ex = False
@@ -92,6 +94,10 @@ def fetch_all_items(oh):
             x = oh.get_item(k)
             dr[k]=x
             x.type_ex = 'devireg_unit'
+            devireg_units_found.append(k)
+    
+    if devireg_units_found:
+        LOGGER.warning(f"Items classified as devireg_unit (separate devices): {devireg_units_found}")
 
     for k,v in items.items():
         is_devi_attr = False
@@ -116,6 +122,8 @@ def fetch_all_items(oh):
                     v.type_ex = 'devireg_attr_ui_switch'
                 else:
                     v.type_ex = 'devireg_attr'
+                    
+                LOGGER.debug(f"Item {k} classified as {v.type_ex} (parent: {v.parent_device_name})")
 
 
         if is_devi_unit==False:

--- a/custom_components/openhab/binary_sensor.py
+++ b/custom_components/openhab/binary_sensor.py
@@ -16,11 +16,17 @@ async def async_setup_entry(
 ) -> None:
     """Setup binary_sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_devices(
-        OpenHABBinarySensor(hass, coordinator, item)
-        for item in coordinator.data.values()
-        if (item.type_ex == 'devireg_attr_ui_binary_sensor') or ( (item.type_ex == False) and (item.type_ in ITEMS_MAP[BINARY_SENSOR]))
-    )
+    
+    binary_sensors = []
+    for item in coordinator.data.values():
+        if (item.type_ex == 'devireg_attr_ui_binary_sensor'):
+            binary_sensors.append(OpenHABBinarySensor(hass, coordinator, item))
+        elif ((item.type_ex == False) and (item.type_ in ITEMS_MAP[BINARY_SENSOR])):
+            binary_sensors.append(OpenHABBinarySensor(hass, coordinator, item))
+    
+    from .const import LOGGER
+    LOGGER.info(f"Binary Sensor platform: Adding {len(binary_sensors)} binary sensor entities")
+    async_add_devices(binary_sensors)
 
 
 class OpenHABBinarySensor(OpenHABEntity, BinarySensorEntity):

--- a/custom_components/openhab/config_flow.py
+++ b/custom_components/openhab/config_flow.py
@@ -103,7 +103,7 @@ class OpenHABFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             schema = {
                 vol.Required(
                     CONF_AUTH_TOKEN, default=user_input.get(CONF_AUTH_TOKEN, "")
-                ): cv.string,  # cv.matches_regex(r"^(oh)\.(.+)\.(.+)$"),
+                ): cv.string,  # cv.matches_regex(r"^(oh)\\.(.+)\\.(.+)$"),
             }
 
         return self.async_show_form(
@@ -144,8 +144,12 @@ class OpenHABOptionsFlowHandler(config_entries.OptionsFlow):
     """openHAB config flow options handler."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry):
-        """Initialize HACS options flow."""
-        self.config_entry = config_entry
+        """Initialize openHAB options flow.
+
+        Note: do NOT assign self.config_entry here - HA sets it automatically
+        via the parent class. Explicit assignment was deprecated in HA 2025.12
+        and removed in HA 2026.x (see bob-tm/ha-openhab#11).
+        """
         self.options = dict(config_entry.options)
 
     async def async_step_init(self, user_input=None):  # pylint: disable=unused-argument

--- a/custom_components/openhab/const.py
+++ b/custom_components/openhab/const.py
@@ -9,7 +9,7 @@ DOMAIN_DATA = f"{DOMAIN}_data"
 VERSION = "0.0.1"
 ATTRIBUTION = "Data provided by openHAB REST API"
 ISSUE_URL = "https://github.com/kubawolanin/ha-openhab/issues"
-DATA_COORDINATOR_UPDATE_INTERVAL = timedelta(seconds=15)
+DATA_COORDINATOR_UPDATE_INTERVAL = timedelta(seconds=60)
 LOGGER: Logger = getLogger(__package__)
 
 # Platforms

--- a/custom_components/openhab/coordinator.py
+++ b/custom_components/openhab/coordinator.py
@@ -216,7 +216,8 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
                 
                 # Track items with None type for debugging
                 if item_type is None:
-                    items_with_none_type.append(f"{item_name} ({type(item).__name__})")
+                    group_type = getattr(item, 'groupType', 'NO_GROUPTYPE')
+                    items_with_none_type.append(f"{item_name} ({type(item).__name__}, groupType={group_type})")
             
             LOGGER.info(f"Item types distribution: {item_types}")
             

--- a/custom_components/openhab/coordinator.py
+++ b/custom_components/openhab/coordinator.py
@@ -176,8 +176,9 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
         LOGGER.info("Shutting down openHAB coordinator")
         self._stop_sse = True
         
-        # Cancel debouncer
-        await self._refresh_debouncer.async_shutdown()
+        # Cancel debouncer - async_shutdown() returns None, don't await it
+        if self._refresh_debouncer is not None:
+            self._refresh_debouncer.async_shutdown()
         
         # Cancel SSE listener task
         if self._sse_listener_task and not self._sse_listener_task.done():

--- a/custom_components/openhab/coordinator.py
+++ b/custom_components/openhab/coordinator.py
@@ -42,6 +42,7 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
             function=self._async_refresh_debounced,
         )
 
+        # Start with normal polling, will be disabled when SSE connects
         super().__init__(
             hass,
             logger=LOGGER,
@@ -64,10 +65,11 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
             )
             LOGGER.info("SSE listener started for real-time updates")
             
-            # Disable regular polling since SSE provides real-time updates
-            # Keep a long interval as fallback in case SSE disconnects
-            self.update_interval = timedelta(minutes=5)
-            LOGGER.info("Reduced polling interval to 5 minutes (SSE active)")
+            # Disable polling completely - SSE provides all updates
+            # Set update_method to None to stop the coordinator from polling
+            self.update_method = None
+            self.update_interval = None
+            LOGGER.info("Disabled polling - using SSE for all updates")
 
     async def _listen_sse_events(self) -> None:
         """Listen to openHAB SSE events manually using aiohttp."""

--- a/custom_components/openhab/coordinator.py
+++ b/custom_components/openhab/coordinator.py
@@ -207,13 +207,21 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
             
             # Count items by type
             item_types = {}
-            for item in items.values():
+            items_with_none_type = []
+            for item_name, item in items.items():
                 item_type = item.type_
                 if item_type not in item_types:
                     item_types[item_type] = 0
                 item_types[item_type] += 1
+                
+                # Track items with None type for debugging
+                if item_type is None:
+                    items_with_none_type.append(f"{item_name} ({type(item).__name__})")
             
             LOGGER.info(f"Item types distribution: {item_types}")
+            
+            if items_with_none_type:
+                LOGGER.warning(f"Items with None type (first 10): {items_with_none_type[:10]}")
             
             # Start SSE listener after first successful fetch
             if items and not self._sse_started:

--- a/custom_components/openhab/coordinator.py
+++ b/custom_components/openhab/coordinator.py
@@ -37,7 +37,7 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
         self._refresh_debouncer = Debouncer(
             hass,
             LOGGER,
-            cooldown=0.5,  # Wait 0.5 seconds after last event before refreshing
+            cooldown=1.5,  # Wait 1.5 seconds after last event before refreshing
             immediate=False,
             function=self._async_refresh_debounced,
         )
@@ -130,9 +130,10 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
                                     event_type = event_data.get('type', '')
                                     topic = event_data.get('topic', '')
                                     
-                                    # Only log user-initiated commands (not periodic sensor updates)
-                                    if event_type == 'ItemCommandEvent':
-                                        LOGGER.debug("Command received: %s", topic)
+                                    # Log ALL item events for debugging
+                                    if 'Item' in event_type and 'items/' in topic:
+                                        item_name = topic.split('/')[-2] if '/' in topic else 'unknown'
+                                        LOGGER.debug(f"SSE Event: {event_type} for {item_name}")
                                     
                                     # Check if it's an item event (any type)
                                     if 'Item' in event_type and 'items/' in topic:

--- a/custom_components/openhab/coordinator.py
+++ b/custom_components/openhab/coordinator.py
@@ -2,10 +2,15 @@
 from __future__ import annotations
 
 from typing import Any
+import asyncio
+import aiohttp
+import json
+from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.debounce import Debouncer
 
 from .api import ApiClientException, OpenHABApiClient
 from .const import DATA_COORDINATOR_UPDATE_INTERVAL, DOMAIN, LOGGER
@@ -22,7 +27,20 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
         self.platforms: list[str] = []
         self.version: str = ""
         self.is_online = False
-        self.ha_items  = {}
+        self.ha_items = {}
+        self._sse_listener_task = None
+        self._stop_sse = False
+        self._sse_session = None
+        self._sse_started = False
+        
+        # Debouncer to prevent too many refreshes
+        self._refresh_debouncer = Debouncer(
+            hass,
+            LOGGER,
+            cooldown=0.5,  # Wait 0.5 seconds after last event before refreshing
+            immediate=False,
+            function=self._async_refresh_debounced,
+        )
 
         super().__init__(
             hass,
@@ -30,6 +48,149 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
             name=DOMAIN,
             update_interval=DATA_COORDINATOR_UPDATE_INTERVAL,
         )
+
+    async def _async_refresh_debounced(self) -> None:
+        """Debounced refresh function."""
+        await self.async_request_refresh()
+
+    def _start_sse_after_first_refresh(self) -> None:
+        """Start SSE listener after first successful refresh."""
+        if not self._sse_started and self.api._base_url:
+            self._sse_started = True
+            # Create task but don't await it - runs in background
+            self._sse_listener_task = self.hass.async_create_background_task(
+                self._listen_sse_events(),
+                name="openhab_sse_listener"
+            )
+            LOGGER.info("SSE listener started for real-time updates")
+
+    async def _listen_sse_events(self) -> None:
+        """Listen to openHAB SSE events manually using aiohttp."""
+        sse_url = f"{self.api._rest_url}/events"
+        
+        # Prepare headers
+        headers = {}
+        if self.api._auth_type == "token" and self.api._auth_token:
+            headers["X-OPENHAB-TOKEN"] = self.api._auth_token
+        
+        retry_delay = 5
+        
+        while not self._stop_sse:
+            try:
+                # Create auth if using basic auth
+                auth = None
+                if self.api._auth_type == "OAuth2" and self.api._username:
+                    auth = aiohttp.BasicAuth(self.api._username, self.api._password)
+                
+                # Create session if needed
+                if not self._sse_session:
+                    self._sse_session = aiohttp.ClientSession()
+                
+                LOGGER.debug("Connecting to SSE endpoint: %s", sse_url)
+                
+                async with self._sse_session.get(
+                    sse_url,
+                    headers=headers,
+                    auth=auth,
+                    timeout=aiohttp.ClientTimeout(total=None, sock_read=300)
+                ) as response:
+                    
+                    if response.status != 200:
+                        error_text = await response.text()
+                        LOGGER.error(
+                            "SSE connection failed with status %s: %s",
+                            response.status,
+                            error_text
+                        )
+                        await asyncio.sleep(retry_delay)
+                        continue
+                    
+                    LOGGER.info("SSE connection established")
+                    
+                    # Read SSE stream line by line
+                    event_data = {}
+                    
+                    async for line in response.content:
+                        if self._stop_sse:
+                            break
+                        
+                        try:
+                            decoded = line.decode('utf-8').strip()
+                            
+                            if not decoded:
+                                # Empty line marks end of event
+                                if event_data:
+                                    event_type = event_data.get('type', '')
+                                    topic = event_data.get('topic', '')
+                                    
+                                    # Only log user-initiated commands (not periodic sensor updates)
+                                    if event_type == 'ItemCommandEvent':
+                                        LOGGER.debug("Command received: %s", topic)
+                                    
+                                    # Check if it's an item event (any type)
+                                    if 'Item' in event_type and 'items/' in topic:
+                                        # Use debouncer to batch ALL item updates into one refresh
+                                        await self._refresh_debouncer.async_call()
+                                    
+                                    event_data = {}
+                                continue
+                            
+                            # Parse SSE field
+                            if ':' in decoded:
+                                field, _, value = decoded.partition(':')
+                                field = field.strip()
+                                value = value.strip()
+                                
+                                if field == 'data':
+                                    # Parse JSON data
+                                    try:
+                                        data = json.loads(value)
+                                        event_data.update(data)
+                                    except json.JSONDecodeError:
+                                        pass
+                                elif field == 'event':
+                                    event_data['event'] = value
+                                elif field == 'id':
+                                    event_data['id'] = value
+                        
+                        except Exception as err:
+                            LOGGER.debug("Error processing SSE line: %s", err)
+            
+            except asyncio.CancelledError:
+                LOGGER.info("SSE listener cancelled")
+                break
+            
+            except Exception as err:
+                if not self._stop_sse:
+                    LOGGER.warning(
+                        "SSE connection error: %s (retrying in %s seconds)",
+                        err,
+                        retry_delay
+                    )
+                    await asyncio.sleep(retry_delay)
+        
+        LOGGER.info("SSE listener stopped")
+
+    async def async_shutdown(self) -> None:
+        """Shutdown the coordinator and stop SSE listener."""
+        LOGGER.info("Shutting down openHAB coordinator")
+        self._stop_sse = True
+        
+        # Cancel debouncer
+        await self._refresh_debouncer.async_shutdown()
+        
+        # Cancel SSE listener task
+        if self._sse_listener_task and not self._sse_listener_task.done():
+            self._sse_listener_task.cancel()
+            try:
+                await self._sse_listener_task
+            except asyncio.CancelledError:
+                pass
+        
+        # Close session
+        if self._sse_session:
+            await self._sse_session.close()
+            self._sse_session = None
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
@@ -39,6 +200,11 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
 
             items = await self.api.async_get_items()
             self.is_online = bool(items)
+            
+            # Start SSE listener after first successful fetch
+            if items and not self._sse_started:
+                self._start_sse_after_first_refresh()
+            
             return items
 
         except ApiClientException as exception:

--- a/custom_components/openhab/coordinator.py
+++ b/custom_components/openhab/coordinator.py
@@ -63,6 +63,11 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
                 name="openhab_sse_listener"
             )
             LOGGER.info("SSE listener started for real-time updates")
+            
+            # Disable regular polling since SSE provides real-time updates
+            # Keep a long interval as fallback in case SSE disconnects
+            self.update_interval = timedelta(minutes=5)
+            LOGGER.info("Reduced polling interval to 5 minutes (SSE active)")
 
     async def _listen_sse_events(self) -> None:
         """Listen to openHAB SSE events manually using aiohttp."""

--- a/custom_components/openhab/coordinator.py
+++ b/custom_components/openhab/coordinator.py
@@ -202,6 +202,11 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
+        # Skip polling if SSE is active - SSE provides real-time updates
+        if self._sse_started:
+            LOGGER.debug("Skipping polling - SSE is active")
+            return self.data if self.data else {}
+        
         try:
             if self.version is None or len(self.version) == 0:
                 self.version = await self.api.async_get_version()

--- a/custom_components/openhab/coordinator.py
+++ b/custom_components/openhab/coordinator.py
@@ -202,6 +202,19 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
             items = await self.api.async_get_items()
             self.is_online = bool(items)
             
+            # Debug logging for item count
+            LOGGER.info(f"Coordinator fetched {len(items)} items from openHAB")
+            
+            # Count items by type
+            item_types = {}
+            for item in items.values():
+                item_type = item.type_
+                if item_type not in item_types:
+                    item_types[item_type] = 0
+                item_types[item_type] += 1
+            
+            LOGGER.info(f"Item types distribution: {item_types}")
+            
             # Start SSE listener after first successful fetch
             if items and not self._sse_started:
                 self._start_sse_after_first_refresh()

--- a/custom_components/openhab/coordinator.py
+++ b/custom_components/openhab/coordinator.py
@@ -395,6 +395,14 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
         Polling is active until _listen_sse_events() disables it after a
         confirmed SSE connection. After that this method may still be invoked
         explicitly via async_request_refresh() as a fallback (e.g. on reconnect).
+
+        All exceptions - including connection errors and timeouts - are caught
+        and re-raised as UpdateFailed so that async_config_entry_first_refresh()
+        converts them into ConfigEntryNotReady.  This causes HA to automatically
+        retry setup instead of marking the integration as permanently broken
+        (setup_error), which is the correct behaviour when openHAB is simply not
+        yet reachable at HA startup time (e.g. after a fast HACS-triggered restart
+        where openHAB needs a few extra seconds to come up).
         """
         try:
             if self.version is None or len(self.version) == 0:
@@ -433,3 +441,9 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
 
         except ApiClientException as exception:
             raise UpdateFailed(exception) from exception
+        except UpdateFailed:
+            raise
+        except Exception as exception:  # noqa: BLE001
+            raise UpdateFailed(
+                f"Unexpected error communicating with openHAB: {exception}"
+            ) from exception

--- a/custom_components/openhab/coordinator.py
+++ b/custom_components/openhab/coordinator.py
@@ -5,7 +5,7 @@ from typing import Any
 import asyncio
 import aiohttp
 import json
-from datetime import timedelta
+import time
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -32,21 +32,28 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
         self._stop_sse = False
         self._sse_session = None
         self._sse_started = False
-        
-        # Track recent commands to avoid processing echo events
-        self._recent_commands = {}  # {item_name: timestamp}
-        self._command_ignore_duration = 2.0  # Ignore state events for 2s after command
-        
-        # Debouncer to prevent too many refreshes
+
+        # Echo suppression: tracks commands explicitly sent by this integration.
+        # Populated via track_ha_command() which entity platforms call right
+        # before they send a command through the HA REST API.  SSE-based
+        # ItemCommandEvents are NOT used for this because the SSE stream does
+        # not expose a reliable source field to distinguish HA-originated
+        # commands from external ones (openHAB rules, other integrations, etc.).
+        self._recent_commands: dict[str, float] = {}
+        self._command_ignore_duration = 2.0  # seconds
+
+        # Fallback debouncer: only used when direct SSE state update fails
+        # (unknown item, parse error) to trigger a full API refresh.
         self._refresh_debouncer = Debouncer(
             hass,
             LOGGER,
-            cooldown=1.5,  # Wait 1.5 seconds after last event before refreshing
+            cooldown=2.0,
             immediate=False,
             function=self._async_refresh_debounced,
         )
 
-        # Start with normal polling, will be disabled when SSE connects
+        # Start with normal polling; disabled inside _listen_sse_events() only
+        # after a confirmed successful SSE connection (HTTP 200).
         super().__init__(
             hass,
             logger=LOGGER,
@@ -55,221 +62,373 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
     async def _async_refresh_debounced(self) -> None:
-        """Debounced refresh function."""
+        """Debounced full API refresh (fallback path only)."""
         await self.async_request_refresh()
 
+    # ------------------------------------------------------------------
+    # Public API for entity platforms
+    # ------------------------------------------------------------------
+
+    def track_ha_command(self, item_name: str) -> None:
+        """Record that this integration just sent a command for item_name.
+
+        Call this immediately before sending a command via the openHAB REST API
+        so that the resulting ItemStateChangedEvent/ItemStateUpdatedEvent from
+        the SSE stream can be identified as an echo and suppressed.
+        """
+        self._recent_commands[item_name] = time.time()
+        LOGGER.debug(
+            "Echo suppression armed for %s (%.1fs window)",
+            item_name,
+            self._command_ignore_duration,
+        )
+
+    # ------------------------------------------------------------------
+    # SSE startup / polling management
+    # ------------------------------------------------------------------
+
     def _start_sse_after_first_refresh(self) -> None:
-        """Start SSE listener after first successful refresh."""
+        """Start SSE listener task after first successful data refresh.
+
+        Polling is NOT disabled here; it is disabled inside _listen_sse_events()
+        only after a confirmed HTTP 200 response from the SSE endpoint so that
+        polling continues as a fallback if the SSE handshake fails.
+        """
         if not self._sse_started and self.api._base_url:
             self._sse_started = True
-            # Create task but don't await it - runs in background
             self._sse_listener_task = self.hass.async_create_background_task(
                 self._listen_sse_events(),
-                name="openhab_sse_listener"
+                name="openhab_sse_listener",
             )
-            LOGGER.info("SSE listener started for real-time updates")
-            
-            # Disable polling completely - SSE provides all updates
-            # Set update_method to None to stop the coordinator from polling
-            self.update_method = None
-            self.update_interval = None
-            LOGGER.info("Disabled polling - using SSE for all updates")
+            LOGGER.info("SSE listener task created")
+
+    def _enable_polling(self) -> None:
+        """Re-enable periodic polling as a fallback while SSE is not connected.
+
+        Called from SSE error paths (non-200 response, connection exception) so
+        that entities are kept up-to-date while the SSE listener retries.
+        Restoring update_interval alone is not enough - we also trigger an
+        immediate refresh so the HA scheduler re-arms itself at the end of that
+        refresh cycle.
+        """
+        if self.update_interval is None:
+            self.update_interval = DATA_COORDINATOR_UPDATE_INTERVAL
+            LOGGER.info(
+                "SSE unavailable - polling re-enabled at %s interval",
+                DATA_COORDINATOR_UPDATE_INTERVAL,
+            )
+            # async_request_refresh() re-schedules the next poll at the end of
+            # _async_refresh(), which honours the restored update_interval.
+            self.hass.async_create_task(self.async_request_refresh())
+
+    # ------------------------------------------------------------------
+    # Direct state injection
+    # ------------------------------------------------------------------
+
+    def _update_item_from_sse_payload(self, item_name: str, payload_str: str) -> bool:
+        """Parse SSE event payload and update the item state in self.data directly.
+
+        Returns True when the item was found and updated successfully.
+        No API call is made; self.data is mutated in-place and callers
+        must follow up with async_set_updated_data(self.data).
+
+        Exception handling policy for item._parse_value():
+        - NotImplementedError / AttributeError: item type has no _parse_value
+          implementation (e.g. bare GroupItem); store raw string as graceful
+          degradation and return True so the caller does NOT fall back to a
+          full API refresh (the entity will display the raw value).
+        - ValueError / TypeError: the value string is present but malformed for
+          this item type; propagate to the outer handler so the method returns
+          False and the fallback API refresh runs.
+        - Any other Exception from json.loads / payload parsing: caught by the
+          outer handler; return False to trigger the fallback refresh.
+        """
+        if not self.data or item_name not in self.data:
+            return False
+
+        try:
+            payload = json.loads(payload_str)
+            raw_value = payload.get("value")
+            if raw_value is None:
+                return False
+
+            item = self.data[item_name]
+            item._raw_state = raw_value
+
+            try:
+                # Each Item subclass implements _parse_value() to convert the
+                # raw string to the typed _state representation.
+                item._state = item._parse_value(raw_value)
+            except (NotImplementedError, AttributeError):
+                # Item type has no _parse_value; store raw string as fallback.
+                item._state = raw_value
+            # ValueError / TypeError are intentionally NOT caught here so they
+            # propagate to the outer except and cause this method to return False.
+
+            LOGGER.debug("SSE direct update: %s = %s", item_name, raw_value)
+            return True
+
+        except Exception as err:  # noqa: BLE001
+            LOGGER.debug(
+                "Could not parse SSE payload for item %s: %s",
+                item_name,
+                err,
+            )
+            return False
+
+    # ------------------------------------------------------------------
+    # SSE listener
+    # ------------------------------------------------------------------
 
     async def _listen_sse_events(self) -> None:
-        """Listen to openHAB SSE events manually using aiohttp."""
+        """Listen to openHAB SSE events and update entity states in real-time."""
         sse_url = f"{self.api._rest_url}/events"
-        
-        # Prepare headers
+
         headers = {}
         if self.api._auth_type == "token" and self.api._auth_token:
             headers["X-OPENHAB-TOKEN"] = self.api._auth_token
-        
+
         retry_delay = 5
-        
+        first_connect = True
+
         while not self._stop_sse:
             try:
-                # Create auth if using basic auth
                 auth = None
                 if self.api._auth_type == "OAuth2" and self.api._username:
                     auth = aiohttp.BasicAuth(self.api._username, self.api._password)
-                
-                # Create session if needed
+
                 if not self._sse_session:
                     self._sse_session = aiohttp.ClientSession()
-                
+
                 LOGGER.debug("Connecting to SSE endpoint: %s", sse_url)
-                
+
                 async with self._sse_session.get(
                     sse_url,
                     headers=headers,
                     auth=auth,
-                    timeout=aiohttp.ClientTimeout(total=None, sock_read=300)
+                    timeout=aiohttp.ClientTimeout(total=None, sock_read=300),
                 ) as response:
-                    
+
                     if response.status != 200:
                         error_text = await response.text()
                         LOGGER.error(
                             "SSE connection failed with status %s: %s",
                             response.status,
-                            error_text
+                            error_text,
                         )
+                        # Re-enable polling so entities are updated while retrying.
+                        self._enable_polling()
                         await asyncio.sleep(retry_delay)
                         continue
-                    
-                    LOGGER.info("SSE connection established")
-                    
-                    # Read SSE stream line by line
-                    event_data = {}
-                    
+
+                    # Connection confirmed - disable polling now that SSE is live.
+                    if self.update_interval is not None:
+                        self.update_method = None
+                        self.update_interval = None
+                        LOGGER.info(
+                            "SSE connection established - polling disabled, "
+                            "SSE is the sole update source"
+                        )
+                    else:
+                        LOGGER.info("SSE reconnected")
+
+                    # After a reconnect, fetch fresh data from the API to catch
+                    # any state changes that occurred while SSE was disconnected.
+                    if not first_connect:
+                        LOGGER.info("SSE reconnected - triggering full refresh")
+                        await self._refresh_debouncer.async_call()
+                    first_connect = False
+
+                    event_data: dict = {}
+
                     async for line in response.content:
                         if self._stop_sse:
                             break
-                        
+
                         try:
-                            decoded = line.decode('utf-8').strip()
-                            
+                            decoded = line.decode("utf-8").strip()
+
                             if not decoded:
-                                # Empty line marks end of event
+                                # Empty line = end of one SSE event block
                                 if event_data:
-                                    event_type = event_data.get('type', '')
-                                    topic = event_data.get('topic', '')
-                                    
-                                    # Extract item name from topic
-                                    item_name = topic.split('/')[-2] if '/' in topic and len(topic.split('/')) > 2 else None
-                                    
-                                    # Track commands to ignore echo events
-                                    if event_type == 'ItemCommandEvent' and item_name:
-                                        import time
-                                        self._recent_commands[item_name] = time.time()
-                                        LOGGER.debug(f"SSE: Command for {item_name}, will ignore echo events for {self._command_ignore_duration}s")
-                                    
-                                    # Check if we should ignore this event (echo after command)
-                                    should_ignore = False
-                                    if item_name and event_type in ['ItemStateEvent', 'ItemStateUpdatedEvent']:
-                                        import time
-                                        cmd_time = self._recent_commands.get(item_name)
-                                        if cmd_time and (time.time() - cmd_time) < self._command_ignore_duration:
-                                            should_ignore = True
-                                            LOGGER.debug(f"SSE: Ignoring {event_type} for {item_name} (echo after command)")
-                                    
-                                    # Log events that we process
-                                    if 'Item' in event_type and 'items/' in topic and not should_ignore:
-                                        LOGGER.debug(f"SSE Event: {event_type} for {item_name}")
-                                    
-                                    # Process state changes (not echo events)
-                                    if 'Item' in event_type and 'items/' in topic and not should_ignore:
-                                        # Use debouncer to batch updates
-                                        await self._refresh_debouncer.async_call()
-                                    
-                                    # Clean up old command timestamps
-                                    if self._recent_commands:
-                                        import time
-                                        now = time.time()
-                                        expired = [k for k, v in self._recent_commands.items() if (now - v) > self._command_ignore_duration]
-                                        for k in expired:
-                                            del self._recent_commands[k]
-                                    
+                                    await self._process_sse_event(event_data)
                                     event_data = {}
                                 continue
-                            
-                            # Parse SSE field
-                            if ':' in decoded:
-                                field, _, value = decoded.partition(':')
+
+                            if ":" in decoded:
+                                field, _, value = decoded.partition(":")
                                 field = field.strip()
                                 value = value.strip()
-                                
-                                if field == 'data':
-                                    # Parse JSON data
+
+                                if field == "data":
                                     try:
                                         data = json.loads(value)
                                         event_data.update(data)
                                     except json.JSONDecodeError:
                                         pass
-                                elif field == 'event':
-                                    event_data['event'] = value
-                                elif field == 'id':
-                                    event_data['id'] = value
-                        
-                        except Exception as err:
+                                elif field in ("event", "id"):
+                                    event_data[field] = value
+
+                        except Exception as err:  # noqa: BLE001
                             LOGGER.debug("Error processing SSE line: %s", err)
-            
+
             except asyncio.CancelledError:
                 LOGGER.info("SSE listener cancelled")
                 break
-            
-            except Exception as err:
+
+            except Exception as err:  # noqa: BLE001
                 if not self._stop_sse:
                     LOGGER.warning(
                         "SSE connection error: %s (retrying in %s seconds)",
                         err,
-                        retry_delay
+                        retry_delay,
                     )
+                    # Re-enable polling so entities are updated while retrying.
+                    self._enable_polling()
                     await asyncio.sleep(retry_delay)
-        
+
         LOGGER.info("SSE listener stopped")
+
+    # ------------------------------------------------------------------
+    # SSE event processing
+    # ------------------------------------------------------------------
+
+    def _prune_recent_commands(self) -> None:
+        """Remove expired entries from _recent_commands.
+
+        Called at every exit point of _process_sse_event() so timestamps never
+        accumulate under high-echo-traffic conditions.
+        """
+        if not self._recent_commands:
+            return
+        now = time.time()
+        expired = [
+            k
+            for k, v in self._recent_commands.items()
+            if (now - v) > self._command_ignore_duration
+        ]
+        for k in expired:
+            del self._recent_commands[k]
+
+    async def _process_sse_event(self, event_data: dict) -> None:
+        """Process a single parsed SSE event from openHAB.
+
+        For ItemStateChangedEvent / ItemStateUpdatedEvent:
+          1. Check echo suppression (only for commands tracked via track_ha_command).
+          2. Try to update the item state directly in self.data (no API call).
+          3. Call async_set_updated_data() so all HA entity listeners fire immediately.
+          4. Fall back to a debounced full API refresh when the item is unknown
+             or the payload cannot be parsed.
+
+        ItemCommandEvent is intentionally ignored here because the SSE stream
+        does not expose a reliable source field; echo suppression is handled
+        exclusively through track_ha_command().
+        """
+        event_type = event_data.get("type", "")
+        topic = event_data.get("topic", "")
+
+        # Extract item name from topic, e.g. "openhab/items/MySwitch/statechanged"
+        parts = topic.split("/")
+        item_name = parts[-2] if len(parts) >= 2 and "items/" in topic else None
+
+        if not item_name:
+            return
+
+        # --- State change / update events ---
+        if event_type in ("ItemStateChangedEvent", "ItemStateUpdatedEvent"):
+            # Suppress echo events for commands explicitly sent by this integration.
+            cmd_time = self._recent_commands.get(item_name)
+            if cmd_time and (time.time() - cmd_time) < self._command_ignore_duration:
+                LOGGER.debug(
+                    "SSE echo suppressed for %s (%s)",
+                    item_name,
+                    event_type,
+                )
+                self._prune_recent_commands()
+                return
+
+            payload_str = event_data.get("payload", "")
+
+            if payload_str and self._update_item_from_sse_payload(item_name, payload_str):
+                # Success: push updated data to all entity listeners immediately.
+                self.async_set_updated_data(self.data)
+            else:
+                # Fallback: item not yet loaded or payload malformed.
+                LOGGER.debug(
+                    "SSE direct update failed for %s - falling back to API refresh",
+                    item_name,
+                )
+                await self._refresh_debouncer.async_call()
+
+        self._prune_recent_commands()
+
+    # ------------------------------------------------------------------
+    # Shutdown
+    # ------------------------------------------------------------------
 
     async def async_shutdown(self) -> None:
         """Shutdown the coordinator and stop SSE listener."""
         LOGGER.info("Shutting down openHAB coordinator")
         self._stop_sse = True
-        
-        # Cancel debouncer - async_shutdown() returns None, don't await it
+
         if self._refresh_debouncer is not None:
             self._refresh_debouncer.async_shutdown()
-        
-        # Cancel SSE listener task
+
         if self._sse_listener_task and not self._sse_listener_task.done():
             self._sse_listener_task.cancel()
             try:
                 await self._sse_listener_task
             except asyncio.CancelledError:
                 pass
-        
-        # Close session
+
         if self._sse_session:
             await self._sse_session.close()
             self._sse_session = None
 
+    # ------------------------------------------------------------------
+    # Coordinator data fetch (polling path - active until SSE connects)
+    # ------------------------------------------------------------------
+
     async def _async_update_data(self) -> dict[str, Any]:
-        """Update data via library."""
-        # Skip polling if SSE is active - SSE provides real-time updates
-        if self._sse_started:
-            LOGGER.debug("Skipping polling - SSE is active")
-            return self.data if self.data else {}
-        
+        """Update data via library.
+
+        Polling is active until _listen_sse_events() disables it after a
+        confirmed SSE connection. After that this method may still be invoked
+        explicitly via async_request_refresh() as a fallback (e.g. on reconnect).
+        """
         try:
             if self.version is None or len(self.version) == 0:
                 self.version = await self.api.async_get_version()
 
             items = await self.api.async_get_items()
             self.is_online = bool(items)
-            
-            # Debug logging for item count
-            LOGGER.info(f"Coordinator fetched {len(items)} items from openHAB")
-            
-            # Count items by type
-            item_types = {}
-            items_with_none_type = []
+
+            LOGGER.info("Coordinator fetched %d items from openHAB", len(items))
+
+            # Log item type distribution for debugging
+            item_types: dict = {}
+            items_with_none_type: list = []
             for item_name, item in items.items():
                 item_type = item.type_
-                if item_type not in item_types:
-                    item_types[item_type] = 0
-                item_types[item_type] += 1
-                
-                # Track items with None type for debugging
+                item_types[item_type] = item_types.get(item_type, 0) + 1
                 if item_type is None:
-                    group_type = getattr(item, 'groupType', 'NO_GROUPTYPE')
-                    items_with_none_type.append(f"{item_name} ({type(item).__name__}, groupType={group_type})")
-            
-            LOGGER.info(f"Item types distribution: {item_types}")
-            
+                    group_type = getattr(item, "groupType", "NO_GROUPTYPE")
+                    items_with_none_type.append(
+                        f"{item_name} ({type(item).__name__}, groupType={group_type})"
+                    )
+
+            LOGGER.info("Item types distribution: %s", item_types)
+
             if items_with_none_type:
-                LOGGER.warning(f"Items with None type (first 10): {items_with_none_type[:10]}")
-            
+                LOGGER.warning(
+                    "Items with None type (first 10): %s",
+                    items_with_none_type[:10],
+                )
+
             # Start SSE listener after first successful fetch
             if items and not self._sse_started:
                 self._start_sse_after_first_refresh()
-            
+
             return items
 
         except ApiClientException as exception:

--- a/custom_components/openhab/cover.py
+++ b/custom_components/openhab/cover.py
@@ -23,6 +23,7 @@ async def async_setup_entry(
         OpenHABCover(hass, coordinator, item)
         for item in coordinator.data.values()
         if item.type_ in ITEMS_MAP[COVER]
+        or (item.type_ == "Group" and hasattr(item, 'groupType') and item.groupType == "Rollershutter")
     )
 
 

--- a/custom_components/openhab/cover.py
+++ b/custom_components/openhab/cover.py
@@ -54,7 +54,7 @@ class OpenHABCover(OpenHABEntity, CoverEntity):
             f"/items/{self._id}",
             str(kwargs[ATTR_POSITION]),
         )
-        await self.coordinator.async_request_refresh()
+        # Don't request refresh - SSE will provide the update
 
     async def async_open_cover(self, **kwargs: dict[str, Any]) -> None:
         """Open the cover."""
@@ -63,7 +63,7 @@ class OpenHABCover(OpenHABEntity, CoverEntity):
         await self.hass.async_add_executor_job(
             self.coordinator.api.openhab.req_post, f"/items/{self._id}", "UP"
         )
-        await self.coordinator.async_request_refresh()
+        # Don't request refresh - SSE will provide the update
 
     async def async_close_cover(self, **kwargs: dict[str, Any]) -> None:
         """Close cover."""
@@ -72,16 +72,16 @@ class OpenHABCover(OpenHABEntity, CoverEntity):
         await self.hass.async_add_executor_job(
             self.coordinator.api.openhab.req_post, f"/items/{self._id}", "DOWN"
         )
-        await self.coordinator.async_request_refresh()
+        # Don't request refresh - SSE will provide the update
 
     async def async_stop_cover(self, **kwargs: dict[str, Any]) -> None:
-        """Close cover."""
+        """Stop cover."""
         if not self.item:
             return
         await self.hass.async_add_executor_job(
             self.coordinator.api.openhab.req_post, f"/items/{self._id}", "STOP"
         )
-        await self.coordinator.async_request_refresh()
+        # Don't request refresh - SSE will provide the update
 
     @property
     def is_closed(self) -> bool:

--- a/custom_components/openhab/cover.py
+++ b/custom_components/openhab/cover.py
@@ -19,12 +19,16 @@ async def async_setup_entry(
     """Setup sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    async_add_devices(
-        OpenHABCover(hass, coordinator, item)
-        for item in coordinator.data.values()
-        if item.type_ in ITEMS_MAP[COVER]
-        or (item.type_ == "Group" and hasattr(item, 'groupType') and item.groupType == "Rollershutter")
-    )
+    covers = []
+    for item in coordinator.data.values():
+        if item.type_ in ITEMS_MAP[COVER]:
+            covers.append(OpenHABCover(hass, coordinator, item))
+        elif (item.type_ == "Group" and hasattr(item, 'groupType') and item.groupType == "Rollershutter"):
+            covers.append(OpenHABCover(hass, coordinator, item))
+    
+    from .const import LOGGER
+    LOGGER.info(f"Cover platform: Adding {len(covers)} cover entities")
+    async_add_devices(covers)
 
 
 class OpenHABCover(OpenHABEntity, CoverEntity):

--- a/custom_components/openhab/entity.py
+++ b/custom_components/openhab/entity.py
@@ -78,20 +78,23 @@ class OpenHABEntity(CoordinatorEntity):
         if oh_version is not None:
             version = oh_version
 
+        # Special handling for devireg devices - create separate device per unit
         if self.item.type_ex in ['devireg_attr', 'devireg_attr_ui_sensor', 'devireg_attr_ui_binary_sensor', 'devireg_attr_ui_switch']:
-            devi_unit = self.item.groupNames[0]
-            return DeviceInfo(
-                identifiers   = {(f"{DOMAIN}.{devi_unit}", self._host)}
-            )
-        else:
-            return DeviceInfo(
-                identifiers={(DOMAIN, self._host)},
-                name=f"{NAME} - {self._host}",
-                model=version,
-                manufacturer=NAME,
-                configuration_url=self._base_url,
-                entry_type=DeviceEntryType.SERVICE,
-            )
+            if self.item.groupNames and len(self.item.groupNames) > 0:
+                devi_unit = self.item.groupNames[0]
+                return DeviceInfo(
+                    identifiers={(DOMAIN, f"{self._host}_{devi_unit}")}
+                )
+        
+        # Default device for all other items
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._host)},
+            name=f"{NAME} - {self._host}",
+            model=version,
+            manufacturer=NAME,
+            configuration_url=self._base_url,
+            entry_type=DeviceEntryType.SERVICE,
+        )
 
     @property
     def device_class(self):

--- a/custom_components/openhab/entity.py
+++ b/custom_components/openhab/entity.py
@@ -1,12 +1,12 @@
 """OpenHABEntity class"""
 from __future__ import annotations
 
+import re
 from typing import Any, List
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.util.slugify import slugify
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from openhab import items
@@ -15,6 +15,21 @@ from .const import ATTRIBUTION, DOMAIN, NAME, VERSION, LOGGER
 from .coordinator import OpenHABDataUpdateCoordinator
 from .icons_map import ICONS_MAP, ITEM_TYPE_MAP
 from .utils import strip_ip
+
+
+def _slugify(text: str) -> str:
+    """Convert text to a valid HA entity ID component.
+
+    Produces a lowercase string containing only [a-z0-9_].
+    Consecutive non-word characters are collapsed into a single underscore,
+    and leading/trailing underscores are stripped.
+
+    This avoids importing from homeassistant.util.slugify whose internal
+    module path changed in HA 2026.x.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "_", text.lower()).strip("_")
+    return slug or "unknown"
+
 
 class OpenHABEntity(CoordinatorEntity):
     """Base openHAB entity."""
@@ -49,7 +64,7 @@ class OpenHABEntity(CoordinatorEntity):
         # HA 2026.2+ enforces strict entity ID validation and rejects raw
         # OpenHAB item names that contain uppercase letters or other characters
         # not permitted in entity IDs.
-        self.entity_id = f"{DOMAIN}.{self._nameid_prefix}{slugify(self.item.name)}"
+        self.entity_id = f"{DOMAIN}.{self._nameid_prefix}{_slugify(self.item.name)}"
 
         if self.item.unit_of_measure:
             self._attr_native_unit_of_measurement = str(self.item.unit_of_measure)

--- a/custom_components/openhab/entity.py
+++ b/custom_components/openhab/entity.py
@@ -6,6 +6,7 @@ from typing import Any, List
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.util.slugify import slugify
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from openhab import items
@@ -43,7 +44,12 @@ class OpenHABEntity(CoordinatorEntity):
         #self._nameid_prefix = f"{self._host}_"
         self._nameid_prefix = f"oh_"
 
-        self.entity_id = f"{DOMAIN}.{self._nameid_prefix}{self.item.name}"
+        # Slugify the item name so the generated entity_id is always a valid
+        # HA identifier (lowercase, no spaces, no special characters).
+        # HA 2026.2+ enforces strict entity ID validation and rejects raw
+        # OpenHAB item names that contain uppercase letters or other characters
+        # not permitted in entity IDs.
+        self.entity_id = f"{DOMAIN}.{self._nameid_prefix}{slugify(self.item.name)}"
 
         if self.item.unit_of_measure:
             self._attr_native_unit_of_measurement = str(self.item.unit_of_measure)
@@ -64,7 +70,12 @@ class OpenHABEntity(CoordinatorEntity):
 
     @property
     def unique_id(self) -> str | None:
-        """Return a unique ID to use for this entity."""
+        """Return a unique ID to use for this entity.
+
+        Uses the original (un-slugified) item name so the entity can always
+        be looked up unambiguously in the HA entity registry, regardless of
+        how the entity_id was slugified.
+        """
         return f"{DOMAIN}.{self._nameid_prefix}{self.item.name}"
 
     @property

--- a/custom_components/openhab/light.py
+++ b/custom_components/openhab/light.py
@@ -27,11 +27,13 @@ async def async_setup_entry(
         OpenHABLightColor(hass, coordinator, item)
         for item in coordinator.data.values()
         if item.type_ == ITEMS_MAP[LIGHT][0]  # Color
+        or (item.type_ == "Group" and hasattr(item, 'groupType') and item.groupType == "Color")
     )
     async_add_devices(
         OpenHABLightDimmer(hass, coordinator, item)
         for item in coordinator.data.values()
         if item.type_ == ITEMS_MAP[LIGHT][1]  # Dimmer
+        or (item.type_ == "Group" and hasattr(item, 'groupType') and item.groupType == "Dimmer")
     )
 
 

--- a/custom_components/openhab/light.py
+++ b/custom_components/openhab/light.py
@@ -67,7 +67,7 @@ class OpenHABLightColor(OpenHABEntity, LightEntity):
             f"/items/{self._id}",
             data=hsv_to_str([hsv[0], hsv[1], 100]),
         )
-        await self.coordinator.async_request_refresh()
+        # Don't request refresh - SSE will provide the update
 
     async def async_turn_off(self, **kwargs):
         """Instruct the light to turn off."""
@@ -79,7 +79,7 @@ class OpenHABLightColor(OpenHABEntity, LightEntity):
             f"/items/{self._id}",
             data=hsv_to_str([hsv[0], hsv[1], 0]),
         )
-        await self.coordinator.async_request_refresh()
+        # Don't request refresh - SSE will provide the update
 
     # @property
     # def color_mode(self) -> str | None:
@@ -123,11 +123,12 @@ class OpenHABLightDimmer(OpenHABEntity, LightEntity):
                 f"/items/{self._id}",
                 str(brightness),
             )
-            return await self.coordinator.async_request_refresh()
+            # Don't request refresh - SSE will provide the update
+            return
         await self.hass.async_add_executor_job(
             self.coordinator.api.openhab.req_post, f"/items/{self._id}", "ON"
         )
-        await self.coordinator.async_request_refresh()
+        # Don't request refresh - SSE will provide the update
 
     async def async_turn_off(self, **kwargs):
         """Instruct the light to turn off."""
@@ -136,4 +137,4 @@ class OpenHABLightDimmer(OpenHABEntity, LightEntity):
         await self.hass.async_add_executor_job(
             self.coordinator.api.openhab.req_post, f"/items/{self._id}", "OFF"
         )
-        await self.coordinator.async_request_refresh()
+        # Don't request refresh - SSE will provide the update

--- a/custom_components/openhab/light.py
+++ b/custom_components/openhab/light.py
@@ -23,18 +23,24 @@ async def async_setup_entry(
     """Setup sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    async_add_devices(
-        OpenHABLightColor(hass, coordinator, item)
-        for item in coordinator.data.values()
-        if item.type_ == ITEMS_MAP[LIGHT][0]  # Color
-        or (item.type_ == "Group" and hasattr(item, 'groupType') and item.groupType == "Color")
-    )
-    async_add_devices(
-        OpenHABLightDimmer(hass, coordinator, item)
-        for item in coordinator.data.values()
-        if item.type_ == ITEMS_MAP[LIGHT][1]  # Dimmer
-        or (item.type_ == "Group" and hasattr(item, 'groupType') and item.groupType == "Dimmer")
-    )
+    color_lights = []
+    for item in coordinator.data.values():
+        if item.type_ == ITEMS_MAP[LIGHT][0]:  # Color
+            color_lights.append(OpenHABLightColor(hass, coordinator, item))
+        elif (item.type_ == "Group" and hasattr(item, 'groupType') and item.groupType == "Color"):
+            color_lights.append(OpenHABLightColor(hass, coordinator, item))
+    
+    dimmer_lights = []
+    for item in coordinator.data.values():
+        if item.type_ == ITEMS_MAP[LIGHT][1]:  # Dimmer
+            dimmer_lights.append(OpenHABLightDimmer(hass, coordinator, item))
+        elif (item.type_ == "Group" and hasattr(item, 'groupType') and item.groupType == "Dimmer"):
+            dimmer_lights.append(OpenHABLightDimmer(hass, coordinator, item))
+    
+    from .const import LOGGER
+    LOGGER.info(f"Light platform: Adding {len(color_lights)} color lights and {len(dimmer_lights)} dimmer lights")
+    async_add_devices(color_lights)
+    async_add_devices(dimmer_lights)
 
 
 class OpenHABLightColor(OpenHABEntity, LightEntity):

--- a/custom_components/openhab/light.py
+++ b/custom_components/openhab/light.py
@@ -3,8 +3,7 @@
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_HS_COLOR,
-    COLOR_MODE_BRIGHTNESS,
-    COLOR_MODE_HS,
+    ColorMode,
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -40,8 +39,8 @@ class OpenHABLightColor(OpenHABEntity, LightEntity):
     """openHAB Color Light class."""
 
     _attr_device_class_map = []
-    _attr_color_mode = COLOR_MODE_BRIGHTNESS
-    _attr_supported_color_modes = {COLOR_MODE_BRIGHTNESS, COLOR_MODE_HS}
+    _attr_color_mode = ColorMode.BRIGHTNESS
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS, ColorMode.HS}
 
     @property
     def is_on(self):
@@ -77,7 +76,7 @@ class OpenHABLightColor(OpenHABEntity, LightEntity):
     # @property
     # def color_mode(self) -> str | None:
     #     """Return the color mode of the light."""
-    #     return COLOR_MODE_HS
+    #     return ColorMode.HS
 
     @property
     def hs_color(self) -> tuple[float, float]:
@@ -90,8 +89,8 @@ class OpenHABLightDimmer(OpenHABEntity, LightEntity):
     """openHAB Dimmer Light class."""
 
     _attr_device_class_map = []
-    _attr_color_mode = COLOR_MODE_BRIGHTNESS
-    _attr_supported_color_modes = {COLOR_MODE_BRIGHTNESS}
+    _attr_color_mode = ColorMode.BRIGHTNESS
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
     @property
     def is_on(self):

--- a/custom_components/openhab/manifest.json
+++ b/custom_components/openhab/manifest.json
@@ -9,7 +9,7 @@
     "bs4",
     "python-openhab==2.17.1"
   ],
-  "version": "0.2",
+  "version": "0.6.1",
   "config_flow": true,
   "codeowners": [
     "@kubawolanin",

--- a/custom_components/openhab/manifest.json
+++ b/custom_components/openhab/manifest.json
@@ -9,7 +9,7 @@
     "bs4",
     "python-openhab==2.17.1"
   ],
-  "version": "0.6.1",
+  "version": "0.2",
   "config_flow": true,
   "codeowners": [
     "@kubawolanin",

--- a/custom_components/openhab/manifest.json
+++ b/custom_components/openhab/manifest.json
@@ -9,7 +9,7 @@
     "bs4",
     "python-openhab==2.17.1"
   ],
-  "version": "0.2.1",
+  "version": "0.6.1",
   "config_flow": true,
   "codeowners": [
     "@kubawolanin",

--- a/custom_components/openhab/manifest.json
+++ b/custom_components/openhab/manifest.json
@@ -9,7 +9,7 @@
     "bs4",
     "python-openhab==2.17.1"
   ],
-  "version": "0.6.1",
+  "version": "0.2.1",
   "config_flow": true,
   "codeowners": [
     "@kubawolanin",

--- a/custom_components/openhab/manifest.json
+++ b/custom_components/openhab/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "openhab",
   "name": "openHAB",
-  "documentation": "https://github.com/bob-tm/ha-openhab",
+  "documentation": "https://github.com/MrDix/ha-openhab",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/bob-tm/ha-openhab/issues",
+  "issue_tracker": "https://github.com/MrDix/ha-openhab/issues",
   "requirements": [
     "zeroconf",
     "bs4",
@@ -13,6 +13,7 @@
   "config_flow": true,
   "codeowners": [
     "@kubawolanin",
-    "@bob-tm"
+    "@bob-tm",
+    "@MrDix"
   ]
 }

--- a/custom_components/openhab/manifest.json
+++ b/custom_components/openhab/manifest.json
@@ -9,6 +9,16 @@
     "bs4",
     "python-openhab>=2.17.1"
   ],
+  "platforms": [
+    "binary_sensor",
+    "cover",
+    "device_tracker",
+    "light",
+    "media_player",
+    "sensor",
+    "switch",
+    "climate"
+  ],
   "version": "0.2",
   "config_flow": true,
   "codeowners": [

--- a/custom_components/openhab/manifest.json
+++ b/custom_components/openhab/manifest.json
@@ -7,7 +7,7 @@
   "requirements": [
     "zeroconf",
     "bs4",
-    "python-openhab==2.17.1"
+    "python-openhab>=2.17.1"
   ],
   "version": "0.2",
   "config_flow": true,

--- a/custom_components/openhab/media_player.py
+++ b/custom_components/openhab/media_player.py
@@ -1,13 +1,9 @@
 """Media Player platform for openHAB."""
 
-from homeassistant.components.media_player import MediaPlayerEntity
-from homeassistant.components.media_player.const import (
-    MEDIA_TYPE_MUSIC,
-    SUPPORT_PLAY,
-    SUPPORT_PAUSE,
-    SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_NEXT_TRACK,
-    SUPPORT_VOLUME_SET,
+from homeassistant.components.media_player import (
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
+    MediaType,
 )
 from homeassistant.const import STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING
 from homeassistant.config_entries import ConfigEntry
@@ -19,11 +15,11 @@ from .device_classes_map import MEDIA_PLAYER_DEVICE_CLASS_MAP
 from .entity import OpenHABEntity
 
 SUPPORT_OPENHAB = (
-    SUPPORT_PLAY
-    | SUPPORT_PAUSE
-    | SUPPORT_PREVIOUS_TRACK
-    | SUPPORT_NEXT_TRACK
-    | SUPPORT_VOLUME_SET
+    MediaPlayerEntityFeature.PLAY
+    | MediaPlayerEntityFeature.PAUSE
+    | MediaPlayerEntityFeature.PREVIOUS_TRACK
+    | MediaPlayerEntityFeature.NEXT_TRACK
+    | MediaPlayerEntityFeature.VOLUME_SET
 )
 
 PLAYBACK_DICT = {
@@ -89,7 +85,7 @@ class OpenHABPlayer(OpenHABEntity, MediaPlayerEntity):
     @property
     def media_content_type(self):
         """Content type of current playing media."""
-        return MEDIA_TYPE_MUSIC
+        return MediaType.MUSIC
 
     @property
     def supported_features(self):

--- a/custom_components/openhab/sensor.py
+++ b/custom_components/openhab/sensor.py
@@ -29,6 +29,9 @@ async def async_setup_entry(
             sensors.append(OpenHABSensor(hass, coordinator, item))
         elif (item.type_ == "Group" and (not hasattr(item, 'groupType') or item.groupType not in specific_group_types)):
             sensors.append(OpenHABSensor(hass, coordinator, item))
+        # Handle untyped GroupItems (type_ = None, no specific groupType)
+        elif (type(item).__name__ == 'GroupItem' and item.type_ is None and (not hasattr(item, 'groupType') or item.groupType is None)):
+            sensors.append(OpenHABSensor(hass, coordinator, item))
     
     LOGGER.info(f"Sensor platform: Adding {len(sensors)} sensor entities out of {len(coordinator.data)} total items")
     async_add_entities(sensors)

--- a/custom_components/openhab/sensor.py
+++ b/custom_components/openhab/sensor.py
@@ -29,9 +29,7 @@ async def async_setup_entry(
             sensors.append(OpenHABSensor(hass, coordinator, item))
         elif (item.type_ == "Group" and (not hasattr(item, 'groupType') or item.groupType not in specific_group_types)):
             sensors.append(OpenHABSensor(hass, coordinator, item))
-        # Handle untyped GroupItems (type_ = None, no specific groupType)
-        elif (type(item).__name__ == 'GroupItem' and item.type_ is None and (not hasattr(item, 'groupType') or item.groupType is None)):
-            sensors.append(OpenHABSensor(hass, coordinator, item))
+        # NOTE: Untyped groups (type_ = None) are now handled as switches, not sensors
     
     LOGGER.info(f"Sensor platform: Adding {len(sensors)} sensor entities out of {len(coordinator.data)} total items")
     async_add_entities(sensors)

--- a/custom_components/openhab/sensor.py
+++ b/custom_components/openhab/sensor.py
@@ -18,10 +18,15 @@ async def async_setup_entry(
     """Setup sensor platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
+    # Define group types that have specific platforms
+    specific_group_types = {"Switch", "Rollershutter", "Color", "Dimmer", "Contact", "Player"}
+
     async_add_entities(
         OpenHABSensor(hass, coordinator, item)
         for item in coordinator.data.values()
-        if (item.type_ex == 'devireg_attr_ui_sensor') or ( (item.type_ex == False) and (item.type_ in ITEMS_MAP[SENSOR]))
+        if (item.type_ex == 'devireg_attr_ui_sensor') 
+        or ((item.type_ex == False) and (item.type_ in ITEMS_MAP[SENSOR]))
+        or (item.type_ == "Group" and (not hasattr(item, 'groupType') or item.groupType not in specific_group_types))
     )
 
 

--- a/custom_components/openhab/sensor.py
+++ b/custom_components/openhab/sensor.py
@@ -22,9 +22,11 @@ async def async_setup_entry(
     specific_group_types = {"Switch", "Rollershutter", "Color", "Dimmer", "Contact", "Player"}
 
     sensors = []
+    skipped_untyped_groups = 0
     for item in coordinator.data.values():
         # Skip untyped groups - they will be handled as switches
         if type(item).__name__ == 'GroupItem' and item.type_ is None and (not hasattr(item, 'groupType') or item.groupType is None):
+            skipped_untyped_groups += 1
             continue
             
         if (item.type_ex == 'devireg_attr_ui_sensor'):
@@ -34,6 +36,7 @@ async def async_setup_entry(
         elif (item.type_ == "Group" and (not hasattr(item, 'groupType') or item.groupType not in specific_group_types)):
             sensors.append(OpenHABSensor(hass, coordinator, item))
     
+    LOGGER.info(f"Sensor platform: Skipped {skipped_untyped_groups} untyped groups (handled as switches)")
     LOGGER.info(f"Sensor platform: Adding {len(sensors)} sensor entities out of {len(coordinator.data)} total items")
     async_add_entities(sensors)
 

--- a/custom_components/openhab/sensor.py
+++ b/custom_components/openhab/sensor.py
@@ -23,13 +23,16 @@ async def async_setup_entry(
 
     sensors = []
     for item in coordinator.data.values():
+        # Skip untyped groups - they will be handled as switches
+        if type(item).__name__ == 'GroupItem' and item.type_ is None and (not hasattr(item, 'groupType') or item.groupType is None):
+            continue
+            
         if (item.type_ex == 'devireg_attr_ui_sensor'):
             sensors.append(OpenHABSensor(hass, coordinator, item))
         elif ((item.type_ex == False) and (item.type_ in ITEMS_MAP[SENSOR])):
             sensors.append(OpenHABSensor(hass, coordinator, item))
         elif (item.type_ == "Group" and (not hasattr(item, 'groupType') or item.groupType not in specific_group_types)):
             sensors.append(OpenHABSensor(hass, coordinator, item))
-        # NOTE: Untyped groups (type_ = None) are now handled as switches, not sensors
     
     LOGGER.info(f"Sensor platform: Adding {len(sensors)} sensor entities out of {len(coordinator.data)} total items")
     async_add_entities(sensors)

--- a/custom_components/openhab/sensor.py
+++ b/custom_components/openhab/sensor.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .const import DOMAIN, ITEMS_MAP, SENSOR
+from .const import DOMAIN, ITEMS_MAP, SENSOR, LOGGER
 from .device_classes_map import SENSOR_DEVICE_CLASS_MAP
 from .entity import OpenHABEntity
 
@@ -21,13 +21,17 @@ async def async_setup_entry(
     # Define group types that have specific platforms
     specific_group_types = {"Switch", "Rollershutter", "Color", "Dimmer", "Contact", "Player"}
 
-    async_add_entities(
-        OpenHABSensor(hass, coordinator, item)
-        for item in coordinator.data.values()
-        if (item.type_ex == 'devireg_attr_ui_sensor') 
-        or ((item.type_ex == False) and (item.type_ in ITEMS_MAP[SENSOR]))
-        or (item.type_ == "Group" and (not hasattr(item, 'groupType') or item.groupType not in specific_group_types))
-    )
+    sensors = []
+    for item in coordinator.data.values():
+        if (item.type_ex == 'devireg_attr_ui_sensor'):
+            sensors.append(OpenHABSensor(hass, coordinator, item))
+        elif ((item.type_ex == False) and (item.type_ in ITEMS_MAP[SENSOR])):
+            sensors.append(OpenHABSensor(hass, coordinator, item))
+        elif (item.type_ == "Group" and (not hasattr(item, 'groupType') or item.groupType not in specific_group_types)):
+            sensors.append(OpenHABSensor(hass, coordinator, item))
+    
+    LOGGER.info(f"Sensor platform: Adding {len(sensors)} sensor entities out of {len(coordinator.data)} total items")
+    async_add_entities(sensors)
 
 
 class OpenHABSensor(OpenHABEntity, SensorEntity):

--- a/custom_components/openhab/switch.py
+++ b/custom_components/openhab/switch.py
@@ -24,7 +24,9 @@ async def async_setup_entry(
     async_add_devices(
         OpenHABBinarySwitch(hass, coordinator, item)
         for item in coordinator.data.values()
-        if (item.type_ex == 'devireg_attr_ui_switch') or ( (item.type_ex == False) and (item.type_ in ITEMS_MAP[SWITCH]))
+        if (item.type_ex == 'devireg_attr_ui_switch') 
+        or ((item.type_ex == False) and (item.type_ in ITEMS_MAP[SWITCH]))
+        or (item.type_ == "Group" and hasattr(item, 'groupType') and item.groupType == "Switch")
     )
 
 

--- a/custom_components/openhab/switch.py
+++ b/custom_components/openhab/switch.py
@@ -43,6 +43,10 @@ async def async_setup_entry(
         elif item.type_ == "Group" and hasattr(item, 'groupType') and item.groupType == "Switch":
             LOGGER.info(f"  Adding switch group: {item.name}")
             switches.append(OpenHABBinarySwitch(hass, coordinator, item))
+        # Treat untyped groups (type_ = None, no groupType) as switches
+        elif type(item).__name__ == 'GroupItem' and item.type_ is None and (not hasattr(item, 'groupType') or item.groupType is None):
+            LOGGER.info(f"  Adding untyped group as switch: {item.name}")
+            switches.append(OpenHABBinarySwitch(hass, coordinator, item))
     
     LOGGER.info(f"Switch platform: Adding {len(switches)} switch entities")
     async_add_devices(switches)

--- a/custom_components/openhab/switch.py
+++ b/custom_components/openhab/switch.py
@@ -29,6 +29,10 @@ async def async_setup_entry(
     
     LOGGER.info(f"Switch platform: Total items: {total_items}, Groups: {len(group_items)}, Switch groups: {len(switch_groups)}")
     
+    # Count how many Switch items we have
+    switch_items = [item for item in coordinator.data.values() if item.type_ == "Switch"]
+    LOGGER.info(f"Switch items available: {len(switch_items)}")
+    
     # Log some group details
     for item in group_items[:5]:  # First 5 groups
         group_type = getattr(item, 'groupType', 'NO_GROUPTYPE')
@@ -60,17 +64,17 @@ class OpenHABBinarySwitch(OpenHABEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: dict[str, Any]) -> None:
         """Turn on the switch."""
         await self.hass.async_add_executor_job(self.item.on)
-        await self.coordinator.async_request_refresh()
+        # Don't request refresh - SSE will provide the update
 
     async def async_turn_off(self, **kwargs: dict[str, Any]) -> None:
         """Turn off the switch."""
         await self.hass.async_add_executor_job(self.item.off)
-        await self.coordinator.async_request_refresh()
+        # Don't request refresh - SSE will provide the update
 
     async def async_toggle(self, **kwargs: dict[str, Any]) -> None:
-        """Turn off the switch."""
+        """Toggle the switch."""
         await self.hass.async_add_executor_job(self.item.toggle)
-        await self.coordinator.async_request_refresh()
+        # Don't request refresh - SSE will provide the update
 
     @property
     def is_on(self) -> bool:

--- a/hacs.json
+++ b/hacs.json
@@ -2,8 +2,6 @@
     "name": "openHAB",
     "hacs": "0.2",
     "render_readme": true,
-    "zip_release": true,
-    "filename": "openhab.zip",
     "domains": [
         "binary_sensor",
         "sensor",

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,8 @@
     "name": "openHAB",
     "hacs": "0.2",
     "render_readme": true,
+    "zip_release": true,
+    "filename": "openhab.zip",
     "domains": [
         "binary_sensor",
         "sensor",


### PR DESCRIPTION
# Improvements: Bug fixes, SSE support, and updated README

This PR includes seven improvements to the openHAB integration:

## 1. Fix NotImplementedError when comparing DateTimeItem objects

**Problem:**
Entity updates fail with `NotImplementedError: 'You can only compare two DateTimeItem objects'` when toggling lights or updating items through Home Assistant.

**Root cause:**
The code in `entity.py` used `if new != None:` which triggers the `__ne__` comparison operator. DateTimeItem objects from the openhab Python library don't implement this operator.

**Solution:**
Changed to `if new is not None:` which uses identity checking instead of comparison operators.

**Files changed:**
- `custom_components/openhab/entity.py`

**Fixes:** #31

---

## 2. Add SSE support for real-time updates from openHAB

**Problem:**
State changes made in openHAB took 15+ seconds to reflect in Home Assistant due to polling-only synchronization.

**Solution:**
Implemented Server-Sent Events (SSE) listener to receive real-time state changes from openHAB's REST API `/rest/events` endpoint.

**Key features:**
- Direct SSE connection using aiohttp (openhab Python library doesn't provide SSE support)
- Background task implementation prevents blocking Home Assistant startup
- Automatic reconnection on connection loss
- Polling re-enabled as fallback when SSE connection fails or returns non-200

**Performance improvements:**
- Reduced synchronization delay from 15+ seconds to under 1 second
- Eliminated redundant refresh operations from periodic sensor updates
- Minimal logging for production use

**Files changed:**
- `custom_components/openhab/coordinator.py` - SSE listener implementation
- `custom_components/openhab/__init__.py` - Removed blocking setup call
- `custom_components/openhab/const.py` - Increased polling interval from 15s to 60s

**Addresses:** #28, #6

---

## 3. Fix SSE state changes not reflected in Home Assistant

**Problem:**
State changes made in openHAB were received via SSE but never updated entity states in Home Assistant. The SSE listener triggered a coordinator refresh, but `_async_update_data()` had an early return when SSE was active, returning stale cached data unchanged.

**Solution:**
Replaced the polling-based refresh approach with direct state injection from SSE payloads:

- New `_update_item_from_sse_payload()` parses the SSE event payload and writes the new value directly into the item object in `self.data` (no API call)
- `async_set_updated_data()` is called immediately after, notifying all entity listeners in real time (~0ms latency)
- Polling is disabled only after a confirmed HTTP 200 SSE connection, and re-enabled automatically on connection loss or errors
- Echo suppression via `track_ha_command()`: entity platforms record commands they send so the resulting SSE echo event can be suppressed without incorrectly blocking external state changes (e.g. from openHAB rules)
- Debounced full API refresh as fallback for unknown items or parse errors

**Files changed:**
- `custom_components/openhab/coordinator.py`

---

## 4. Fix deprecated constant imports for Home Assistant 2025.10+ compatibility

**Problem:**
The integration fails to load in Home Assistant 2025.10 and later due to deprecated constants being removed from Home Assistant core.

**Error:**
```
ImportError: cannot import name 'MEDIA_TYPE_MUSIC' from 'homeassistant.components.media_player.const'
```

**Root cause:**
Home Assistant 2025.10 removed deprecated string constants in favor of enum-based constants:
- `MEDIA_TYPE_MUSIC`, `SUPPORT_*` constants removed from `media_player.const`
- `COLOR_MODE_*` constants removed from `light` component

**Solution:**
Updated imports to use new enum-based constants:

**media_player.py:**
- `MEDIA_TYPE_MUSIC` → `MediaType.MUSIC`
- `SUPPORT_PLAY` → `MediaPlayerEntityFeature.PLAY`
- `SUPPORT_PAUSE` → `MediaPlayerEntityFeature.PAUSE`
- `SUPPORT_PREVIOUS_TRACK` → `MediaPlayerEntityFeature.PREVIOUS_TRACK`
- `SUPPORT_NEXT_TRACK` → `MediaPlayerEntityFeature.NEXT_TRACK`
- `SUPPORT_VOLUME_SET` → `MediaPlayerEntityFeature.VOLUME_SET`

**light.py:**
- `COLOR_MODE_BRIGHTNESS` → `ColorMode.BRIGHTNESS`
- `COLOR_MODE_HS` → `ColorMode.HS`

**Files changed:**
- `custom_components/openhab/media_player.py`
- `custom_components/openhab/light.py`

**Fixes:** #5, #10

---

## 5. Fix deprecated `self.config_entry` assignment in OptionsFlow (HA 2025.12+)

**Problem:**
Home Assistant 2025.12 deprecated and subsequently removed the pattern of explicitly setting `self.config_entry` in `OptionsFlow.__init__()`. This triggered deprecation warnings and stops working in HA 2026.x.

**Solution:**
Removed the explicit `self.config_entry = config_entry` assignment from `OpenHABOptionsFlowHandler.__init__()`. The parent class sets `config_entry` automatically after `async_get_options_flow()` returns. Accessing `self.config_entry` in `async_step_user()` continues to work as before.

**Files changed:**
- `custom_components/openhab/config_flow.py`

**Fixes:** #11

---

## 6. Fix invalid entity ID for openHAB items with uppercase/special characters (HA 2026.2+)

**Problem:**
Home Assistant 2026.2 enforces strict entity ID validation. openHAB item names may contain uppercase letters or other characters not permitted in HA entity IDs, causing `HomeAssistantError: Invalid entity ID` for any such item.

**Solution:**
The item name is now passed through `slugify()` before being used in the `entity_id` (produces lowercase, underscore-separated identifiers). The `unique_id` continues to use the original item name so the entity can be looked up unambiguously in the HA entity registry.

**Files changed:**
- `custom_components/openhab/entity.py`

**Fixes:** #12

---

## 7. Revise README with updates and new repository link

Updated README to reflect current repository location, integration status, and document all recent improvements.

**Files changed:**
- `README.md`

---

## Testing

Tested with:
- Home Assistant 2025.10.4 through 2026.2+
- openHAB 4.3.10
- Multiple item types (lights, switches, sensors, buttons)
- Items with uppercase names and special characters

All features working as expected:
- Entity updates no longer fail with NotImplementedError
- State changes from openHAB appear in Home Assistant within 1 second
- Home Assistant startup completes without delays
- SSE connection remains stable over extended periods
- Integration loads successfully in Home Assistant 2025.10+
- Options flow works without deprecation warnings in HA 2025.12+
- All entity IDs generated correctly in HA 2026.2+

---

## Breaking Changes

None. All changes are backward compatible.

Note: Entity IDs for items with uppercase names will change after this update (e.g. `openhab.oh_MySwitch` becomes `openhab.oh_myswitch`). Automations or dashboards referencing such entity IDs by name will need to be updated, or can be re-mapped via the entity registry.

---

## Checklist

- [x] Code follows the project's style guidelines
- [x] Changes have been tested locally
- [x] No new warnings or errors introduced
- [x] Documentation (README) updated where applicable